### PR TITLE
chore(deps): bump Altinn.Dd.Tests.SonarGate to 2.0.1 (clears SSH.NET GHSA-q939-rpr3-3284)

### DIFF
--- a/QaTests/QaTests.csproj
+++ b/QaTests/QaTests.csproj
@@ -5,7 +5,7 @@
     <Nullable>enable</Nullable>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Altinn.Dd.Tests.SonarGate" Version="2.0.0" />
+    <PackageReference Include="Altinn.Dd.Tests.SonarGate" Version="2.0.1" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.0.1" />
     <PackageReference Include="xunit" Version="2.9.3" />
     <PackageReference Include="xunit.runner.visualstudio" Version="3.1.5">


### PR DESCRIPTION
Clears **GHSA-q939-rpr3-3284** — SSH.NET `<= 2025.1.0`, **high**, CVSS 7.1 (arbitrary file write via server-controlled SCP filenames).

SSH.NET reached the `QaTests` project transitively:

```
Altinn.Dd.Tests.SonarGate 2.0.0 > Testcontainers 4.9.0 > SSH.NET 2025.1.0
```

SonarGate **2.0.1** references Testcontainers **4.14.0** — the first Testcontainers release that depends on the patched SSH.NET 2026.0.0. (4.13.0 still pulls 2025.1.0.)

### Verification

`dotnet list package --vulnerable --include-transitive`, .NET SDK 10.0.201, nuget.org only:

- **before** — `SSH.NET 2025.1.0  High  GHSA-q939-rpr3-3284`
- **after** — *no vulnerable packages given the current sources*

### Why Dependabot never flagged this

There is no `packages.lock.json` in this repo, so GitHub's dependency graph only sees direct `PackageReference` entries. Every transitive NuGet advisory is invisible to it. Setting `<RestorePackagesWithLockFile>true</RestorePackagesWithLockFile>` and committing the lockfile would close that gap — worth a separate change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated the QA test tooling to the latest patch version, improving compatibility and reliability of automated quality checks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->